### PR TITLE
Fix styleguide blue text

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -213,8 +213,8 @@
 						<td>
 							<div class="blue colour_swatch">
 								<div class="cmyk">C0 M0 Y0 K01</div>
-								<div class="rgb">R252 G252 B252</div>
-								<div class="hex">#131313</div>
+								<div class="rgb">R57 G158 B207</div>
+								<div class="hex">#399ecf</div>
 							</div>
 						</td>
 						<td><div class="colour_swatch"></div></td>


### PR DESCRIPTION
@artsworks The rgb code for the blue is a very light grey and the hex is the lux-black. Don't know how the values for cmyk are being used here since I thought their values should be 0 < n < 1?

![image](https://cloud.githubusercontent.com/assets/1182539/8897287/d0f80624-3455-11e5-9db4-f9a85386e521.png)
